### PR TITLE
Shorten AI Track Journey section for clarity and conciseness

### DIFF
--- a/view/index.html
+++ b/view/index.html
@@ -78,10 +78,9 @@ For the duration of 140 days of NCS course, I have completely absorbed myself in
 						<img class="profile-image" src="images/tonyillust_atwork.svg" alt="tonyleekorea" />
 					</div>
 					<div class="col-md-4 col-xs-8">
-						<h3>Front to Backend</h3>
+						<h3>AI Track Journey</h3>
 						<p>
-							SIMPLE AND HUMBLE BEGINNING
-From the graphic designer with hands-on experience in the industry, I witnessed myself transform into a full-fledged web developer covering both front-end and back-end offices
+							CURIOUS AND HUMBLE BEGINNING From my first steps experimenting with Korean language learning content and simple speech pipelines, I slowly found myself drawn into the world of artificial intelligence. What began as small curiosities soon grew into practical systems—running LLaMA locally with GPU acceleration, integrating TinyLLaMA into Wazuh SIEM rules, and blending AI with infrastructure to reveal new possibilities. Along the way, I built real applications, from an MVP chat app evolving into scalable WebSocket architectures to embedding Ollama inside TUI dashboards for productivity. Now with Xanthorox AI’s modular design guiding my vision, I continue shaping AI across education, cybersecurity, and systems integration, carrying forward the same spirit of learning and transformation that marked my earliest experiments.
 						</p>
 					</div>
 				</div>

--- a/view/index.html
+++ b/view/index.html
@@ -78,10 +78,10 @@ For the duration of 140 days of NCS course, I have completely absorbed myself in
 						<img class="profile-image" src="images/tonyillust_atwork.svg" alt="tonyleekorea" />
 					</div>
 					<div class="col-md-4 col-xs-8">
-						<h3>AI Track Journey</h3>
-						<p>
-							CURIOUS AND HUMBLE BEGINNING From my first steps experimenting with Korean language learning content and simple speech pipelines, I slowly found myself drawn into the world of artificial intelligence. What began as small curiosities soon grew into practical systems—running LLaMA locally with GPU acceleration, integrating TinyLLaMA into Wazuh SIEM rules, and blending AI with infrastructure to reveal new possibilities. Along the way, I built real applications, from an MVP chat app evolving into scalable WebSocket architectures to embedding Ollama inside TUI dashboards for productivity. Now with Xanthorox AI’s modular design guiding my vision, I continue shaping AI across education, cybersecurity, and systems integration, carrying forward the same spirit of learning and transformation that marked my earliest experiments.
-						</p>
+					<h3>AI Track Journey</h3>
+					<p>
+						Started with language learning and speech pipelines, then built practical AI systems: LLaMA, TinyLLaMA for SIEM, and Ollama in dashboards. Focused on modular, real-world AI for education, cybersecurity, and productivity.
+					</p>
 					</div>
 				</div>
 				


### PR DESCRIPTION
This PR shortens the AI Track Journey section in the profile to match the concise style of the front and backend descriptions.